### PR TITLE
Possible extraction bug?

### DIFF
--- a/core/src/test/scala/org/bowlerframework/controller/ExtractingOptionalParametersTest.scala
+++ b/core/src/test/scala/org/bowlerframework/controller/ExtractingOptionalParametersTest.scala
@@ -1,0 +1,35 @@
+package uk.ac.rvc.veqel.controllers
+
+import org.scalatra.test.scalatest.ScalatraFunSuite
+import org.scalatest.matchers.ShouldMatchers
+import org.bowlerframework.http.BowlerFilter
+import uk.ac.rvc.veqel.startup.transformers.Transformers
+import org.bowlerframework.controller.{Controller, FunctionNameConventionRoutes}
+import uk.ac.rvc.veqel.bowler.{JsonSerialisationFormats, DefaultBowlerConfiguration}
+import net.liftweb.json._
+
+case class Extracted (param1:Option[Int], param2:Option[Int])
+
+class ExtractorController extends Controller with FunctionNameConventionRoutes {
+  def `GET /extract`(param1:Option[Int], param2:Option[Int]) = {
+    Extracted(param1, param2)
+  }
+}
+
+class ExtractingOptionalParametersTest extends ScalatraFunSuite with ShouldMatchers {
+  val holder = this.addFilter(classOf[BowlerFilter], "/*")
+
+  test("Routing and serialisation for analysising commonality in a patient list") {
+    val bootstrap = new DefaultBowlerConfiguration with Transformers
+    val sut = new ExtractorBugController
+
+    get("/extract?param1=999") {
+
+      import JsonSerialisationFormats._
+
+      val results = parse(body).extract[Extracted]
+      val expectedResult = Extracted(Some(999), None)
+      results should be (expectedResult)
+    }
+  }
+}


### PR DESCRIPTION
Hi Wille,

I think I have found a bug with extraction of optional parameters.  If you have two optional parameters and only one is provided in the querystring, the send parameter will be set to the first's value instead of None.

I think I have managed to create a failing test for this which is in the pull request. This fails in my project but at the moment I am unable to get bowler building for some reason!

Let me know if I can do anything else to clarify what I mean!

Cheers,

Noel
